### PR TITLE
[DRAFT]: Adding to the TODO so that I remember what to do for the future

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 To do before adding more code
 
-1. Move all dock block descriptions to their respective `README.md` files.
 1. Get the `./src/_sandbox/index.js` working with `Rollup` in `--watch` mode
   - Will likely need the [@rollup/plugin-run](https://www.npmjs.com/package/@rollup/plugin-run) plugin
 1. Create a file `./tools/.eslintrc.json` to take the `eslint` configs out of `package.json`
+1. For documentation generation I will most likely use [HyperBook](https://hyperbook.openpatch.org/)
+  - Since I do not want to completely convert my repo just for `HyperBook` I plan to write a script to copy over all the `markdown` files to a website directory following the folder structure I already have
+  - Requires me to change the filenames of many/all of the `markdown` files. I can't use `README.md` for all the files anymore as I would prefer to use a generator and not Github Repo viewer to show the documentation


### PR DESCRIPTION
## Purpose
I want to have a static website that showcases the "Computer Science in JavaScript" reference that I'm currently putting together. 

## Why
I do not believe that using Github's repo viewer to see all the documentation is a great experience as one is required to go into each folder to see the rendered markdown files. Instead I want an experience where all the documentation is shown in 

## How
### Libraries/Platforms to use
- [`Hugo`](https://gohugo.io/)
- [`Hyperbook`](https://github.com/openpatch/hyperbook)

### Changes
It is important to have this script run on "watch mode" so any changes locally are reflected in a running theme in `dev` mode.

## Gotchas
Almost all static site builders require their own custom directory structure and I preferred the method of letting it pull the markdown from my `./src` and `./philosophies` directories but that seems to not be possible for most. Therefore I plan to create a `./website` directory and will house all the theme code and the content will be pulled from the `./src` directory and I will use a script to put it all in the `./website/content` directory exactly as it is in the `./src` directory. At least that is the hope.

The website will be hosted on Github Pages and run on `CI/CD` when merging into `main`

## Acceptance Criteria

| Criterion | Reason |
|---|---|
| Content transformation | I need to be able to write all of my content where I want it and have the `markdown` files moved to the `./content` directory and all the images reflected in the same folder structure.| 
| Live reloads | I want to be able to view my changes as I make them and see them reflected on the website in the dev server| 
| GitHub Pages | I want the documentation to be viewable as a static site.| 
| CI/CD | I want to publish new changes whenever I push to main| 

---
Note: The initial commit is so I do not lose my thoughts that I put into the `TODO.md` file.


